### PR TITLE
Fix 'unmarshalling' typo

### DIFF
--- a/yaml/build.go
+++ b/yaml/build.go
@@ -23,7 +23,7 @@ type (
 	}
 )
 
-// UnmarshalYAML implements yaml unmarhsaling.
+// UnmarshalYAML implements yaml unmarshalling.
 func (b *Build) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	d := new(build)
 	err := unmarshal(&d.Image)

--- a/yaml/cond.go
+++ b/yaml/cond.go
@@ -57,7 +57,7 @@ func (c *Condition) Excludes(v string) bool {
 	return false
 }
 
-// UnmarshalYAML implements yml unmarhsaling.
+// UnmarshalYAML implements yml unmarshalling.
 func (c *Condition) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var out1 []string
 	var out2 = struct {

--- a/yaml/env.go
+++ b/yaml/env.go
@@ -17,7 +17,7 @@ type (
 	}
 )
 
-// UnmarshalYAML implements yaml unmarhsaling.
+// UnmarshalYAML implements yaml unmarshalling.
 func (v *Variable) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	d := new(variable)
 	err := unmarshal(&d.Value)

--- a/yaml/param.go
+++ b/yaml/param.go
@@ -16,7 +16,7 @@ type (
 	}
 )
 
-// UnmarshalYAML implements yaml unmarhsaling.
+// UnmarshalYAML implements yaml unmarshalling.
 func (p *Parameter) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	d := new(parameter)
 	err := unmarshal(d)

--- a/yaml/port.go
+++ b/yaml/port.go
@@ -16,7 +16,7 @@ type (
 	}
 )
 
-// UnmarshalYAML implements yaml unmarhsaling.
+// UnmarshalYAML implements yaml unmarshalling.
 func (p *Port) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	out := new(port)
 	err := unmarshal(&out.Port)

--- a/yaml/push.go
+++ b/yaml/push.go
@@ -13,7 +13,7 @@ type (
 	}
 )
 
-// UnmarshalYAML implements yaml unmarhsaling.
+// UnmarshalYAML implements yaml unmarshalling.
 func (p *Push) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	d := new(push)
 	err := unmarshal(&d.Image)

--- a/yaml/unit.go
+++ b/yaml/unit.go
@@ -7,7 +7,7 @@ import "github.com/docker/go-units"
 // (eg. "44kiB", "17MiB").
 type BytesSize int64
 
-// UnmarshalYAML implements yaml unmarhsaling.
+// UnmarshalYAML implements yaml unmarshalling.
 func (b *BytesSize) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var intType int64
 	if err := unmarshal(&intType); err == nil {


### PR DESCRIPTION
I happened to be playing with UnmarshalYAML(interface{}) error and was using this repo for reference and noticed the cheeky copy-pasta typo