### PR TITLE
Fix typo: linter message about untrusted repositories unnable to mount volumes

### DIFF
--- a/yaml/linter/linter.go
+++ b/yaml/linter/linter.go
@@ -124,14 +124,14 @@ func checkVolumes(pipeline *yaml.Pipeline, trusted bool) error {
 
 func checkHostPathVolume(volume *yaml.VolumeHostPath, trusted bool) error {
 	if trusted == false {
-		return errors.New("linter: untrusted repsitories cannot mount host volumes")
+		return errors.New("linter: untrusted repositories cannot mount host volumes")
 	}
 	return nil
 }
 
 func checkEmptyDirVolume(volume *yaml.VolumeEmptyDir, trusted bool) error {
 	if trusted == false && volume.Medium == "memory" {
-		return errors.New("linter: untrusted repsitories cannot mount in-memory volumes")
+		return errors.New("linter: untrusted repositories cannot mount in-memory volumes")
 	}
 	return nil
 }

--- a/yaml/linter/linter_test.go
+++ b/yaml/linter/linter_test.go
@@ -53,7 +53,7 @@ func TestLint(t *testing.T) {
 			path:    "testdata/volume_host_path.yml",
 			trusted: false,
 			invalid: true,
-			message: "linter: untrusted repsitories cannot mount host volumes",
+			message: "linter: untrusted repositories cannot mount host volumes",
 		},
 		{
 			path:    "testdata/volume_host_path.yml",
@@ -74,7 +74,7 @@ func TestLint(t *testing.T) {
 			path:    "testdata/volume_empty_dir_memory.yml",
 			trusted: false,
 			invalid: true,
-			message: "linter: untrusted repsitories cannot mount in-memory volumes",
+			message: "linter: untrusted repositories cannot mount in-memory volumes",
 		},
 		{
 			path:    "testdata/volume_empty_dir_memory.yml",


### PR DESCRIPTION
Simply replacing "repsitories" to "repositories".

Two occurrences, fixed in the functions and tests as well. 