### PR TITLE
if it doesn't have a from_secret map, then continue to unmarshall as …

### DIFF
--- a/yaml/param.go
+++ b/yaml/param.go
@@ -20,7 +20,7 @@ type (
 func (p *Parameter) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	d := new(parameter)
 	err := unmarshal(d)
-	if err == nil {
+	if err == nil && d.Secret != ""{
 		p.Secret = d.Secret
 		return nil
 	}


### PR DESCRIPTION
…a normal map

@bradrydzewski This should fix the ability to inject maps as well as lists and string to the settings