### PR TITLE
Use USERPROFILE on Windows for netrc path

### DIFF
--- a/yaml/compiler/script_win.go
+++ b/yaml/compiler/script_win.go
@@ -28,25 +28,25 @@ func setupScriptWin(spec *engine.Spec, dst *engine.Step, src *yaml.Container) {
 	dst.Docker.Command = []string{"powershell", "-noprofile", "-noninteractive", "-command"}
 	dst.Docker.Args = []string{"[System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($Env:CI_SCRIPT)) | iex"}
 	dst.Envs["CI_SCRIPT"] = base64.StdEncoding.EncodeToString([]byte(script))
-	dst.Envs["HOME"] = "c:\\root"
 	dst.Envs["SHELL"] = "powershell.exe"
 }
 
 // buildScriptWin is a helper script this is added to the build
 // to prepare the environment and execute the build commands.
 const buildScriptWin = `
-$ErrorActionPreference = 'Stop';
-&cmd /c "mkdir c:\root";
 if ($Env:CI_NETRC_MACHINE) {
-$netrc=[string]::Format("{0}\_netrc",$Env:HOME);
-"machine $Env:CI_NETRC_MACHINE" >> $netrc;
-"login $Env:CI_NETRC_USERNAME" >> $netrc;
-"password $Env:CI_NETRC_PASSWORD" >> $netrc;
-};
-[Environment]::SetEnvironmentVariable("CI_NETRC_PASSWORD",$null);
-[Environment]::SetEnvironmentVariable("CI_SCRIPT",$null);
-[Environment]::SetEnvironmentVariable("DRONE_NETRC_USERNAME",$null);
-[Environment]::SetEnvironmentVariable("DRONE_NETRC_PASSWORD",$null);
+@"
+machine $Env:CI_NETRC_MACHINE
+login $Env:CI_NETRC_USERNAME
+password $Env:CI_NETRC_PASSWORD
+"@ > (Join-Path $Env:USERPROFILE '_netrc');
+}
+[Environment]::SetEnvironmentVariable("CI_NETRC_USERNAME", $null);
+[Environment]::SetEnvironmentVariable("CI_NETRC_PASSWORD", $null);
+[Environment]::SetEnvironmentVariable("DRONE_NETRC_USERNAME", $null);
+[Environment]::SetEnvironmentVariable("DRONE_NETRC_PASSWORD", $null);
+[Environment]::SetEnvironmentVariable("CI_SCRIPT", $null);
+$ErrorActionPreference = 'Stop';
 %s
 `
 

--- a/yaml/compiler/transform/netrc.go
+++ b/yaml/compiler/transform/netrc.go
@@ -20,21 +20,37 @@ func WithNetrc(machine, username, password string) func(*engine.Spec) {
 		if username == "" || password == "" {
 			return
 		}
-		netrc := generateNetrc(machine, username, password)
-		spec.Files = append(spec.Files, &engine.File{
-			Metadata: engine.Metadata{
-				UID:       rand.String(),
-				Name:      netrcName,
-				Namespace: spec.Metadata.Namespace,
-			},
-			Data: []byte(netrc),
-		})
-		for _, step := range spec.Steps {
-			step.Files = append(step.Files, &engine.FileMount{
-				Name: netrcName,
-				Path: netrcPath,
-				Mode: netrcMode,
+
+		// Currently file mounts don't seem to work in Windows so environment
+		// variables are used instead
+		// FIXME: https://github.com/drone/drone-yaml/issues/20
+		if spec.Platform.OS != "windows" {
+			netrc := generateNetrc(machine, username, password)
+			spec.Files = append(spec.Files, &engine.File{
+				Metadata: engine.Metadata{
+					UID:       rand.String(),
+					Name:      netrcName,
+					Namespace: spec.Metadata.Namespace,
+				},
+				Data: []byte(netrc),
 			})
+			for _, step := range spec.Steps {
+				step.Files = append(step.Files, &engine.FileMount{
+					Name: netrcName,
+					Path: netrcPath,
+					Mode: netrcMode,
+				})
+			}
+		} else {
+			for _, step := range spec.Steps {
+				step.Envs["CI_NETRC_MACHINE"] = machine
+				step.Envs["CI_NETRC_USERNAME"] = username
+				step.Envs["CI_NETRC_PASSWORD"] = password
+
+				step.Envs["DRONE_NETRC_MACHINE"] = machine
+				step.Envs["DRONE_NETRC_USERNAME"] = username
+				step.Envs["DRONE_NETRC_PASSWORD"] = password
+			}
 		}
 	}
 }


### PR DESCRIPTION
By default Git on Windows looks in `%USERPROFILE%` for a `_netrc` file so use that rather than creating a home directory.

Other things changed
* Mirroring unset from posix implementation. Not sure what `CI_SCRIPT` was doing in there.
* Moved `$ErrorActionPreference = 'Stop';` to the end of the script to mirror what's happening in the posix implementation with `set -x`.