### PR TITLE
enable to copy host files to Docker volume instead of mounting the host directory

### DIFF
--- a/yaml/compiler/compiler.go
+++ b/yaml/compiler/compiler.go
@@ -96,7 +96,9 @@ func (c *Compiler) Compile(from *yaml.Pipeline) *engine.Spec {
 			Version: from.Platform.Version,
 			Variant: from.Platform.Variant,
 		},
-		Docker:  &engine.DockerConfig{},
+		Docker: &engine.DockerConfig{
+			CopyHost: from.Clone.CopyHost,
+		},
 		Files:   nil,
 		Secrets: nil,
 	}

--- a/yaml/compiler/workspace.go
+++ b/yaml/compiler/workspace.go
@@ -129,6 +129,23 @@ func CreateHostWorkspace(workdir string) func(*engine.Spec) {
 	}
 }
 
+func CreateCopyHostWorkspace() func(*engine.Spec) {
+	return func(spec *engine.Spec) {
+		CreateWorkspace(spec)
+		spec.Docker.Volumes = append(spec.Docker.Volumes,
+			&engine.Volume{
+				Metadata: engine.Metadata{
+					UID:       rand.String(),
+					Name:      workspaceHostName,
+					Namespace: spec.Metadata.Namespace,
+					Labels:    map[string]string{},
+				},
+				EmptyDir: &engine.VolumeEmptyDir{},
+			},
+		)
+	}
+}
+
 //
 //
 //

--- a/yaml/pipeline.go
+++ b/yaml/pipeline.go
@@ -47,6 +47,7 @@ type (
 		Disable    bool `json:"disable,omitempty"`
 		Depth      int  `json:"depth,omitempty"`
 		SkipVerify bool `json:"skip_verify,omitempty" yaml:"skip_verify"`
+		CopyHost   bool `json:",omitempty"`
 	}
 
 	// Concurrency limits pipeline concurrency.


### PR DESCRIPTION
* Issue: https://discourse.drone.io/t/proposal-add-the-flag-to-drone-exec-command-to-copy-hosts-current-directory-to-the-docker-volume-instead-of-mounting-the-hosts-current-directory/4431

The following pull request depends on this pull request.

* https://github.com/drone/drone-cli/pull/123

This pull request depends on the following pull request.

* https://github.com/drone/drone-runtime/pull/70