### PR TITLE
Add IpcMode

### DIFF
--- a/yaml/compiler/step.go
+++ b/yaml/compiler/step.go
@@ -43,6 +43,7 @@ func createStep(spec *engine.Spec, src *yaml.Container) *engine.Step {
 			DNSSearch:  src.DNSSearch,
 			ExtraHosts: src.ExtraHosts,
 			Image:      image.Expand(src.Image),
+			IPC:        src.IPC,
 			Networks:   nil, // set in compiler.go
 			Ports:      toPorts(src),
 			Privileged: src.Privileged,

--- a/yaml/linter/linter.go
+++ b/yaml/linter/linter.go
@@ -153,6 +153,9 @@ func checkContainer(container *yaml.Container, trusted bool) error {
 	if trusted == false && len(container.ExtraHosts) > 0 {
 		return errors.New("linter: untrusted repositories cannot configure extra_hosts")
 	}
+	if trusted == false && len(container.IPC) > 0 {
+		return errors.New("linter: untrusted repositories cannot configure ipc")
+	}
 	for _, mount := range container.Volumes {
 		switch mount.Name {
 		case "workspace", "_workspace", "_docker_socket":

--- a/yaml/pipeline.go
+++ b/yaml/pipeline.go
@@ -69,6 +69,7 @@ type (
 		ExtraHosts  []string              `json:"extra_hosts,omitempty" yaml:"extra_hosts"`
 		Failure     string                `json:"failure,omitempty"`
 		Image       string                `json:"image,omitempty"`
+		IPC         string                `json:"ipc,omitempty" yaml:"ipc"`
 		Name        string                `json:"name,omitempty"`
 		Ports       []*Port               `json:"ports,omitempty"`
 		Privileged  bool                  `json:"privileged,omitempty"`

--- a/yaml/pretty/container.go
+++ b/yaml/pretty/container.go
@@ -42,6 +42,7 @@ func printContainer(w writer, v *yaml.Container) {
 	w.WriteTagValue("dns", v.DNS)
 	w.WriteTagValue("dns_search", v.DNSSearch)
 	w.WriteTagValue("extra_hosts", v.ExtraHosts)
+	w.WriteTagValue("ipc", v.IPC)
 
 	if len(v.Settings) > 0 {
 		printSettings(w, v.Settings)


### PR DESCRIPTION
Together with a PR in drone-runtime, this adds support for using `ipc` as documented in docker-compose: https://docs.docker.com/compose/compose-file/#domainname-hostname-ipc-mac_address-privileged-read_only-shm_size-stdin_open-tty-user-working_dir

I will be testing to ensure the containers work as expected tomorrow, but I'm putting these PRs now in case the maintainers have any feedback for me before I get too deep.